### PR TITLE
Update to vrs 2.0.0 snapshot 2025 02.3

### DIFF
--- a/.requirements.txt
+++ b/.requirements.txt
@@ -5,3 +5,4 @@ pyyaml
 ga4gh.gks.metaschema==0.3.1
 jsonschema
 referencing
+pre-commit

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,8 @@ master_doc = 'index'
 # N.B. RTD ignores these values. :-/
 release = _get_git_tag()
 version = _parse_release_as_version(release)
+# Automatically use the RTD branch/tag as the GitHub version
+github_version = os.environ.get("READTHEDOCS_VERSION", "main")
 
 # -- Schema doc paths --------------------------------------------------------
 
@@ -74,6 +76,17 @@ todo_emit_warnings = True
 #
 html_theme = 'sphinx_rtd_theme'
 html_logo = 'images/GA-logo.png'
+
+html_theme_options = {
+    'collapse_navigation': False
+}
+html_context = {
+    "conf_py_path": "/docs/source/",
+    "display_github": True,
+    "github_user": "ga4gh",
+    "github_repo": "cat-vrs",
+    "github_version": github_version,
+}
 
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/examples/canonicalAllele-ex1.yaml
+++ b/examples/canonicalAllele-ex1.yaml
@@ -42,8 +42,14 @@ constraints:
         - name: clinvar hgvs type
           value: genomic, top-level
     relations:
-      - primaryCode: liftover_to
-      - primaryCode: transcribes_to
+      - primaryCoding:
+          code: liftover_to
+          system: ga4gh-gks-term:allele-relation
+      - primaryCoding:
+          code: transcribed_to
+          system: http://www.sequenceontology.org
+          iris:
+            - http://www.sequenceontology.org/browser/current_release/term/transcribed_to
 mappings:
   - coding:
       code: CA915941124

--- a/examples/categoricalCnv-ex1.yaml
+++ b/examples/categoricalCnv-ex1.yaml
@@ -15,9 +15,13 @@ constraints:
         refgetAccession: SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO
         residueAlphabet: na
     relations:
-      - primaryCode: liftover_to
+      - primaryCoding:
+          code: liftover_to
+          system: ga4gh-gks-term:allele-relation
     matchCharacteristic:
-      primaryCode: is_within
+      primaryCoding:
+        code: is_within
+        system: ga4gh-gks-term:location-match
 extensions:
   - name: vrs processing errors
     value: "NC_000007.14:g.(?_5905831)_(6014161_?)dup: char 26: expected one of '=', 'con', 'copy', 'del', 'dup', 'ins', or 'inv'"

--- a/examples/categoricalCnv-ex2.yaml
+++ b/examples/categoricalCnv-ex2.yaml
@@ -15,9 +15,13 @@ constraints:
         refgetAccession: SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO
         residueAlphabet: na
     relations:
-      - primaryCode: liftover_to
+      - primaryCoding:
+          code: liftover_to
+          system: ga4gh-gks-term:allele-relation
     matchCharacteristic:
-      primaryCode: is_within
+      primaryCoding:
+        code: is_within
+        system: ga4gh-gks-term:location-match
 extensions:
   - name: vrs processing errors
     value: "NC_000007.14:g.(?_5905831)_(6014161_?)dup: char 26: expected one of '=', 'con', 'copy', 'del', 'dup', 'ins', or 'inv'"

--- a/examples/proteinSequenceConsequence-ex1.yaml
+++ b/examples/proteinSequenceConsequence-ex1.yaml
@@ -14,7 +14,11 @@ constraints:
   - type: DefiningAlleleConstraint
     allele: vrs.json#/ga4gh:VA.kgjrhgf84CEndyLjKdAO0RxN-e3pJjxA
     relations:
-      - primaryCode: translates_from
+      - primaryCoding:
+          code: translation_of
+          system: http://www.sequenceontology.org
+          iris:
+            - http://www.sequenceontology.org/browser/current_release/term/translation_of
 members:
   - vrs.json#/ga4gh:VA.7jX7fHgVEqx4C4jMRyZOH0ZBHnLn7_gJ
   - vrs.json#/ga4gh:VA.3_FsKSUHEdurPIw5gqpw6g0_Ga0TEXQh

--- a/schema/cat-vrs/cat-vrs-source.yaml
+++ b/schema/cat-vrs/cat-vrs-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/cat-vrs-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/cat-vrs-source.yaml"
 title: GA4GH-Cat-VRS-Definitions
 type: object
 strict: true
@@ -9,8 +9,8 @@ imports:
   vrs: ../vrs/vrs-source.yaml
 
 namespaces:
-  gks.core: /ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/
-  vrs: /ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/
+  gks.core: /ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/
+  vrs: /ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/
 
 $defs:
 

--- a/schema/cat-vrs/json/CanonicalAllele
+++ b/schema/cat-vrs/json/CanonicalAllele
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CanonicalAllele",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CanonicalAllele",
    "title": "CanonicalAllele",
    "type": "object",
    "maturity": "trial use",
    "description": "A canonical allele is defined by an Allele that is representative of a collection of congruent Alleles, each of which depict the same nucleic acid different underlying reference sequences. Congruent representations of an Allele often exist across different genome assemblies and associated cDNA transcript representations.",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CategoricalVariant"
+         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CategoricalVariant"
       },
       {
          "properties": {
@@ -17,7 +17,7 @@
                "contains": {
                   "allOf": [
                      {
-                        "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/DefiningAlleleConstraint"
+                        "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/DefiningAlleleConstraint"
                      },
                      {
                         "type": "object",
@@ -28,8 +28,13 @@
                                     "contains": {
                                        "type": "object",
                                        "properties": {
-                                          "primaryCode": {
-                                             "const": "liftover_to"
+                                          "primaryCoding": {
+                                             "code": {
+                                                "const": "liftover_to"
+                                             },
+                                             "system": {
+                                                "const": "ga4gh-gks-term:allele-relation"
+                                             }
                                           }
                                        }
                                     }
@@ -38,8 +43,13 @@
                                     "contains": {
                                        "type": "object",
                                        "properties": {
-                                          "primaryCode": {
-                                             "const": "transcribes_to"
+                                          "primaryCoding": {
+                                             "code": {
+                                                "const": "transcribed_to"
+                                             },
+                                             "system": {
+                                                "const": "http://www.sequenceontology.org"
+                                             }
                                           }
                                        }
                                     }

--- a/schema/cat-vrs/json/CategoricalCnv
+++ b/schema/cat-vrs/json/CategoricalCnv
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CategoricalCnv",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CategoricalCnv",
    "title": "CategoricalCnv",
    "type": "object",
    "maturity": "draft",
    "description": "A representation of the constraints for matching knowledge about CNVs.",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CategoricalVariant"
+         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CategoricalVariant"
       },
       {
          "properties": {
@@ -20,15 +20,20 @@
                      "contains": {
                         "allOf": [
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/DefiningLocationConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/DefiningLocationConstraint"
                            },
                            {
                               "properties": {
                                  "relations": {
                                     "contains": {
                                        "properties": {
-                                          "primaryCode": {
-                                             "const": "liftover_to"
+                                          "primaryCoding": {
+                                             "code": {
+                                                "const": "liftover_to"
+                                             },
+                                             "system": {
+                                                "const": "ga4gh-gks-term:allele-relation"
+                                             }
                                           }
                                        }
                                     }
@@ -42,10 +47,10 @@
                      "contains": {
                         "oneOf": [
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CopyCountConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CopyCountConstraint"
                            },
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CopyChangeConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CopyChangeConstraint"
                            }
                         ]
                      }

--- a/schema/cat-vrs/json/CategoricalVariant
+++ b/schema/cat-vrs/json/CategoricalVariant
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CategoricalVariant",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CategoricalVariant",
    "title": "CategoricalVariant",
    "type": "object",
    "maturity": "trial use",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -50,10 +50,10 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
                },
                {
-                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Variation"
+                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Variation"
                }
             ]
          }
@@ -64,16 +64,16 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CopyChangeConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CopyChangeConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CopyCountConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CopyCountConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/DefiningAlleleConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/DefiningAlleleConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/DefiningLocationConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/DefiningLocationConstraint"
                }
             ]
          }
@@ -82,7 +82,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/ConceptMapping"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/ConceptMapping"
          },
          "description": "A list of mappings to concepts in terminologies or code systems. Each mapping should include a coding and a relation."
       }

--- a/schema/cat-vrs/json/Constraint
+++ b/schema/cat-vrs/json/Constraint
@@ -1,22 +1,22 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/Constraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/Constraint",
    "title": "Constraint",
    "type": "object",
    "maturity": "trial use",
    "description": "Constraints are used to construct an intensional semantics of categorical variant types.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CopyChangeConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CopyChangeConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CopyCountConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CopyCountConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/DefiningAlleleConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/DefiningAlleleConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/DefiningLocationConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/DefiningLocationConstraint"
       }
    ]
 }

--- a/schema/cat-vrs/json/CopyChangeConstraint
+++ b/schema/cat-vrs/json/CopyChangeConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CopyChangeConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CopyChangeConstraint",
    "title": "CopyChangeConstraint",
    "type": "object",
    "maturity": "draft",

--- a/schema/cat-vrs/json/CopyCountConstraint
+++ b/schema/cat-vrs/json/CopyCountConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CopyCountConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CopyCountConstraint",
    "title": "CopyCountConstraint",
    "type": "object",
    "maturity": "trial use",
@@ -16,7 +16,7 @@
          "description": "The precise value or range of copies members of this categorical variant must satisfy.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Range"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Range"
             },
             {
                "type": "integer"

--- a/schema/cat-vrs/json/DefiningAlleleConstraint
+++ b/schema/cat-vrs/json/DefiningAlleleConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/DefiningAlleleConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/DefiningAlleleConstraint",
    "title": "DefiningAlleleConstraint",
    "type": "object",
    "maturity": "trial use",
@@ -15,10 +15,10 @@
       "allele": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Allele"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Allele"
             }
          ]
       },
@@ -26,7 +26,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/MappableConcept"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/MappableConcept"
          },
          "description": "Defined relationships from which members relate to the defining allele."
       }

--- a/schema/cat-vrs/json/DefiningLocationConstraint
+++ b/schema/cat-vrs/json/DefiningLocationConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/DefiningLocationConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/DefiningLocationConstraint",
    "title": "DefiningLocationConstraint",
    "type": "object",
    "maturity": "trial use",
@@ -15,10 +15,10 @@
       "location": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/SequenceLocation"
             }
          ]
       },
@@ -26,13 +26,13 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/MappableConcept"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/MappableConcept"
          },
          "description": "Defined relationships from which members relate to the defining location."
       },
       "matchCharacteristic": {
          "description": "A characteristic of the location that is used to match the defining location to member locations.",
-         "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/MappableConcept"
       }
    },
    "required": [

--- a/schema/cat-vrs/json/ProteinSequenceConsequence
+++ b/schema/cat-vrs/json/ProteinSequenceConsequence
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/ProteinSequenceConsequence",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/ProteinSequenceConsequence",
    "title": "ProteinSequenceConsequence",
    "type": "object",
    "maturity": "trial use",
    "description": "A change that occurs in a protein sequence as a result of genomic changes. Due to the degenerate nature of the genetic code, there are often several genomic changes that can cause a protein sequence consequence. The protein sequence consequence, like a CanonicalAllele, is defined by an Allele that is representative of a collection of congruent Protein Alleles that share the same altered codon(s).",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/CategoricalVariant"
+         "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/CategoricalVariant"
       },
       {
          "properties": {
@@ -15,7 +15,7 @@
                "contains": {
                   "allOf": [
                      {
-                        "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/json/DefiningAlleleConstraint"
+                        "$ref": "/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/json/DefiningAlleleConstraint"
                      },
                      {
                         "type": "object",
@@ -26,8 +26,13 @@
                                     "contains": {
                                        "type": "object",
                                        "properties": {
-                                          "primaryCode": {
-                                             "const": "translates_from"
+                                          "primaryCoding": {
+                                             "code": {
+                                                "const": "translation_of"
+                                             },
+                                             "system": {
+                                                "const": "http://www.sequenceontology.org"
+                                             }
                                           }
                                        }
                                     }

--- a/schema/cat-vrs/recipes-source.yaml
+++ b/schema/cat-vrs/recipes-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.1/recipes-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0-snapshot.2025-02.2/recipes-source.yaml"
 title: GA4GH-Cat-VRS-Recipe-Definitions
 type: object
 
@@ -28,8 +28,11 @@ $defs:
                         - contains:
                             type: object
                             properties:
-                              primaryCode:
-                                const: translates_from
+                              primaryCoding:
+                                code:
+                                  const: translation_of
+                                system:
+                                  const: http://www.sequenceontology.org
                       maxContains: 1
 
   CanonicalAllele:
@@ -55,13 +58,19 @@ $defs:
                         - contains:
                             type: object
                             properties:
-                              primaryCode:
-                                const: liftover_to
+                              primaryCoding:
+                                code:
+                                  const: liftover_to
+                                system:
+                                  const: ga4gh-gks-term:allele-relation
                         - contains:
                             type: object
                             properties:
-                              primaryCode:
-                                const: transcribes_to
+                              primaryCoding:
+                                code:
+                                  const: transcribed_to
+                                system:
+                                  const: http://www.sequenceontology.org
                       maxContains: 2
 
   CategoricalCnv:
@@ -86,8 +95,11 @@ $defs:
                         relations:
                           contains:
                             properties:
-                              primaryCode:
-                                const: liftover_to
+                              primaryCoding:
+                                code:
+                                  const: liftover_to
+                                system:
+                                  const: ga4gh-gks-term:allele-relation
               - contains:
                   oneOf:
                     - $ref: CopyCountConstraint


### PR DESCRIPTION
- update to the vrs 2.0 snapshot 2025-02.3 references
- prep new v2 of 1.0.0 snapshot 2025-02 release ($ids update)
- modify RTD config to re-add "Edit in Github" link