### PR TITLE
build: use latest metaschema processor release

### DIFF
--- a/.requirements.txt
+++ b/.requirements.txt
@@ -2,7 +2,7 @@ pytest
 sphinx ~= 7.2
 sphinx-rtd-theme ~= 1.2
 pyyaml
-ga4gh.gks.metaschema==0.3.1
+ga4gh.gks.metaschema==0.3.2
 jsonschema
 referencing
 pre-commit


### PR DESCRIPTION
This *hypothetically* should fix issues with generated text introducing new trailing whitespace/line ending problems, but let me know if you see anything else that breaks (I will mostly take responsibility)
