### PR TITLE
#135: Update stale-bot to not close Issues and Pull Requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,6 +19,5 @@ jobs:
         stale-pr-label: Stale
         stale-pr-message: >-
           This pull request was marked stale due to inactivity.
-        days-before-stale: 60
-        days-before-close: 14
+        days-before-stale: 90
         exempt-issue-label: "Stayin' Alive"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,4 +20,5 @@ jobs:
         stale-pr-message: >-
           This pull request was marked stale due to inactivity.
         days-before-stale: 90
+        days-before-close: -1
         exempt-issue-label: "Stayin' Alive"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,10 +13,10 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-label: Stale
+        stale-issue-label: stale
         stale-issue-message: >-
           This issue was marked stale due to inactivity.
-        stale-pr-label: Stale
+        stale-pr-label: stale
         stale-pr-message: >-
           This pull request was marked stale due to inactivity.
         days-before-stale: 90


### PR DESCRIPTION
This Pull Request for [Issue #135: Revise stale-bot to not close Issues and Pull Requests](https://github.com/ga4gh/cat-vrs/issues/135). 

We made the following changes:
- Changed Stale-bot to _not_ close Issues and Pull Requests.
- Changed time-to-stale from 60 days to 90 days.
- Changed the applied label to be lower case, from "Stale" to "stale", to align with the style of other labels within this repository.

FYI - I created this Pull Request based on the ballot branch, [1.0.0-ballot.2025-03](https://github.com/ga4gh/cat-vrs/tree/1.0.0-ballot.2025-03), instead of 1.x. I can update this change to be relative to 1.x so that the bot gets updated sooner, if that is preferred. 