### PR TITLE
#131: Adjust CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Each line is a file pattern followed by one or more owners.
-@cat-vrs-maintainers
+* @ga4gh/cat-vrs-maintainers


### PR DESCRIPTION
This Pull Request is for [Issue #131: Add CODEOWNERS file](https://github.com/ga4gh/cat-vrs/issues/131). 

Here, we make an adjustment to the CODEOWNERS file to properly reference the @ga4gh/cat-vrs-maintainers team. [GitHub requires Teams to be identified in the format `@org/team-name`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file). 

GitHub requires Teams to have explicit **Write** access to the repository as a CODEOWNER, and the cat-vrs-maintainers team has **Maintain** access to this repository, [which is an access level above **Write**](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#repository-roles-for-organizations). 

---
**Current access**:
<img width="575" height="354" alt="Current access to cat-vrs repo" src="https://github.com/user-attachments/assets/725994db-d22e-440a-86ec-7fca2993c75b" />

---

The Issue also outlined that the Default Branch should require review from CODEOWNERS, which is enabled. 

---
**Current Branch Protection rules for the default branch**:
<img width="575" height="572" alt="Current Branch Protection rules for the default branch" src="https://github.com/user-attachments/assets/a54c096a-72c2-488e-a3e1-890333098f23" />

---

Pull Request checklist:
- [x] Does the title of this Pull Request reference the corresponding Issue?
- [x] Is the branch validating against pre-commit hooks? Run `pre-commit run --all-files` from the root directory.
- [x] Is the branch passing tests? Run `pytest tests/` from the root directory.

Neither examples nor the schema were contributed to in this Pull Request. The branch is validating against all pre-commit hooks and passing tests. 