### PR TITLE
Issue 170

### DIFF
--- a/docs/source/concepts/catvrs_model.rst
+++ b/docs/source/concepts/catvrs_model.rst
@@ -22,10 +22,7 @@ description of a categorical variant.
 Constraint
 ##########
 
-The *Constraint* class is an abstract class that is the parent of all
-other constraint classes.  A constraint is a rule or set of rules that
-must be satisfied for a CategoricalVariant to be considered valid.
-Constraint sub classes are only used in CategoricalVariant objects.
+The *Constraint* class is an abstract class that is the parent of all other constraint classes.  A constraint is a rule or set of rules that must be satisfied for a variant to be considered valid member of the CategoricalVariant. Constraint sub classes are only used in CategoricalVariant objects.
 
 .. _DefiningAlleleConstraint:
 


### PR DESCRIPTION
https://github.com/ga4gh/cat-vrs/issues/170

## Summary

Fixes incorrect description of `Constraint` in the documentation as reported in #170.

The current documentation states that constraints validate a CategoricalVariant itself, but constraints actually validate whether a variant is a valid **member** of the CategoricalVariant.

## Changes
- Updated `Constraint` description in `docs/source/concepts/catvrs_model.rst` to clarify that constraints validate variant membership in a CategoricalVariant

## Pull Request checklist:
- [x] Does the title of this Pull Request reference the corresponding Issue?
- [ ] Is the branch validating against pre-commit hooks? Run `pre-commit run --all-files` from the root directory. *(documentation-only change)*
- [ ] Is the branch passing tests? Run `pytest tests/` from the root directory. *(documentation-only change)*

If the schema or examples were contributed to:
- [ ] Were the schema def/ and json/ files recompiled and committed? Run `cd schema; make all` from the root directory. *(not applicable)*
- [ ] If constraints or recipes were added, have they been added to the readthedocs? To do so, you can revise the appropriate file within `docs/source/concepts/`. *(not applicable)*
- [x] Has documentation been regenerated and committed? Run `cd docs; make clean watch &` from the root directory to compile documentation.
- [ ] Have tests been created or updated? *(not applicable - documentation fix)*