### PR TITLE
docs: (#149) remove html margin-top blocks

### DIFF
--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -71,3 +71,11 @@ div.figure div.legend p:last-child {
 span.std-term::after {
     content: " 🛈"
 }
+
+details {
+    margin-top: 0.5em;
+}
+
+details:last-child {
+    margin-bottom: 1.0em;
+}

--- a/docs/source/concepts/catvrs_model.rst
+++ b/docs/source/concepts/catvrs_model.rst
@@ -41,19 +41,11 @@ The following are example implementations of DefiningAlleleConstraint:
       :language: json
       :lines: 83-172
 
-.. raw:: html
-
-   <div style="margin-top: 0.5em;"></div>
-
 .. collapse:: NC_000001.11:g.1699974C>G
 
    .. literalinclude:: ../../../schema/cat-vrs/json/example_canonicalAllele-ex2
       :language: json
       :lines: 37-112
-
-.. raw:: html
-
-   <div style="margin-top: 0.5em;"></div>
 
 .. collapse:: EGFR L858R
 
@@ -61,19 +53,11 @@ The following are example implementations of DefiningAlleleConstraint:
       :language: json
       :lines: 99-150
 
-.. raw:: html
-
-   <div style="margin-top: 0.5em;"></div>
-
 .. collapse:: NM_007294.4(BRCA1):c.5558dup (p.Tyr1853Ter)
 
    .. literalinclude:: ../../../schema/cat-vrs/json/example_proteinSequenceConsequence-ex2
       :language: json
       :lines: 69-132
-
-.. raw:: html
-
-   <div style="margin-top: 1em;"></div>
 
 .. _DefiningLocationConstraint:
 

--- a/docs/source/concepts/recipes.rst
+++ b/docs/source/concepts/recipes.rst
@@ -34,18 +34,10 @@ The following are example implementations of that satisfy the CanonicalAllele re
    .. literalinclude:: ../../../schema/cat-vrs/json/example_canonicalAllele-ex1
       :language: json
 
-.. raw:: html
-
-   <div style="margin-top: 0.5em;"></div>
-
 .. collapse:: NC_000001.11:g.1699974C>G
 
    .. literalinclude:: ../../../schema/cat-vrs/json/example_canonicalAllele-ex2
       :language: json
-
-.. raw:: html
-
-   <div style="margin-top: 1em;"></div>
 
 .. _categorical-cnv:
 
@@ -69,27 +61,15 @@ The following are example implementations of that satisfy the CategoricalCNV rec
    .. literalinclude:: ../../../schema/cat-vrs/json/example_categoricalCnv-ex1
       :language: json
 
-.. raw:: html
-
-   <div style="margin-top: 0.5em;"></div>
-
 .. collapse:: GRCh38/hg38 7p22.1(chr7:5905831-6014161)x3 with CopyChangeConstraint
 
    .. literalinclude:: ../../../schema/cat-vrs/json/example_categoricalCnv-ex2
       :language: json
 
-.. raw:: html
-
-   <div style="margin-top: 0.5em;"></div>
-
 .. collapse:: GRCh38 Xp22.31(chrX:6978350-7594949)x3
 
    .. literalinclude:: ../../../schema/cat-vrs/json/example_categoricalCnv-ex3
       :language: json
-
-.. raw:: html
-
-   <div style="margin-top: 1em;"></div>
 
 .. _ProteinSequenceConsequence:
 
@@ -112,18 +92,10 @@ The following are example implementations of that satisfy the ProteinSequenceCon
    .. literalinclude:: ../../../schema/cat-vrs/json/example_proteinSequenceConsequence-ex1
       :language: json
 
-.. raw:: html
-
-   <div style="margin-top: 0.5em;"></div>
-
 .. collapse:: NM_007294.4(BRCA1):c.5558dup (p.Tyr1853Ter)
 
    .. literalinclude:: ../../../schema/cat-vrs/json/example_proteinSequenceConsequence-ex2
       :language: json
-
-.. raw:: html
-
-   <div style="margin-top: 1em;"></div>
 
 .. _FunctionVariant:
 
@@ -146,24 +118,12 @@ The following are example implementations of that satisfy the FunctionVariant re
    .. literalinclude:: ../../../schema/cat-vrs/json/example_functionVariant-ex1
       :language: json
 
-.. raw:: html
-
-   <div style="margin-top: 0.5em;"></div>
-
 .. collapse:: BRCA2 loss of function variants
 
    .. literalinclude:: ../../../schema/cat-vrs/json/example_functionVariant-ex2
       :language: json
 
-.. raw:: html
-
-   <div style="margin-top: 0.5em;"></div>
-
 .. collapse:: PIK3CA p.R38H
 
    .. literalinclude:: ../../../schema/cat-vrs/json/example_functionVariant-ex3
       :language: json
-
-.. raw:: html
-
-   <div style="margin-top: 0.5em;"></div>


### PR DESCRIPTION
Close #149

Replace HTML blocks that manually injected some spacing via `margin-top` with two CSS rules provided in the theme_override CSS module

Pull Request checklist:
- [x] Does the title of this Pull Request reference the corresponding Issue?
- [x] Is the branch validating against pre-commit hooks? Run `pre-commit run --all-files` from the root directory.
- [x] Is the branch passing tests? Run `pytest tests/` from the root directory.

If the schema or examples were contributed to:
- [x] Were the schema def/ and json/ files recompiled and committed? Run `cd schema; make all` from the root directory.
- [x] If constraints or recipes were added, have they been added to the readthedocs? To do so, you can revise the appropriate file within `docs/source/concepts/`.
- [x] Has documentation been regenerated and committed? Run `cd docs; make clean watch &` from the root directory to compile documentation.
- [x] Have tests been created or updated?
