### PR TITLE
Docs: auto update copyright year, aligned copyright text with other GKS products

### DIFF
--- a/.requirements.txt
+++ b/.requirements.txt
@@ -1,6 +1,6 @@
 pytest
-sphinx ~= 7.2
-sphinx-rtd-theme ~= 1.2
+sphinx ~= 8.1.3
+sphinx-rtd-theme ~= 3.0.2
 pyyaml
 ga4gh.gks.metaschema==0.3.2
 jsonschema

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,7 @@ def _parse_release_as_version(rls):
 # -- Project information -----------------------------------------------------
 
 project = "GA4GH Categorical Variation Representation Specification"
-copyright = "2023-%Y, GA4GH CatVRS Contributors"
+copyright = "2023-%Y, GA4GH CatVRS Contributors."
 author = "Committers"
 master_doc = "index"
 # N.B. RTD ignores these values. :-/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,16 +13,23 @@
 import os
 import re
 import subprocess
+
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+
 def _get_git_tag():
-    res = subprocess.run("git describe --tags --exact-match".split(), capture_output=True)
+    res = subprocess.run(
+        "git describe --tags --exact-match".split(), capture_output=True
+    )
     if res.stderr.decode().startswith("fatal"):
         # if no exact tag, then get branch
-        res = subprocess.run("git rev-parse --abbrev-ref HEAD".split(), capture_output=True)
+        res = subprocess.run(
+            "git rev-parse --abbrev-ref HEAD".split(), capture_output=True
+        )
     tag = res.stdout.decode().strip()
     return tag
+
 
 def _parse_release_as_version(rls):
     m = re.match(r"^(\d+\.\d+)", rls)
@@ -33,10 +40,10 @@ def _parse_release_as_version(rls):
 
 # -- Project information -----------------------------------------------------
 
-project = 'GA4GH Categorical Variation Representation Specification'
-copyright = '2023, GA4GH CatVar Study Group'
-author = 'Committers'
-master_doc = 'index'
+project = "GA4GH Categorical Variation Representation Specification"
+copyright = "2023-%Y, GA4GH CatVRS Contributors"
+author = "Committers"
+master_doc = "index"
 # N.B. RTD ignores these values. :-/
 release = _get_git_tag()
 version = _parse_release_as_version(release)
@@ -45,7 +52,7 @@ github_version = os.environ.get("READTHEDOCS_VERSION", "main")
 
 # -- Schema doc paths --------------------------------------------------------
 
-rst_epilog_fn = os.path.join(os.path.dirname(__file__), 'rst_epilog')
+rst_epilog_fn = os.path.join(os.path.dirname(__file__), "rst_epilog")
 rst_epilog = open(rst_epilog_fn).read().format(release=release)
 
 # -- General configuration ---------------------------------------------------
@@ -53,13 +60,10 @@ rst_epilog = open(rst_epilog_fn).read().format(release=release)
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    'sphinx.ext.todo',
-    'sphinx_toolbox.collapse'
-]
+extensions = ["sphinx.ext.todo", "sphinx_toolbox.collapse"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -75,12 +79,10 @@ todo_emit_warnings = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
-html_logo = 'images/GA-logo.png'
+html_theme = "sphinx_rtd_theme"
+html_logo = "images/GA-logo.png"
 
-html_theme_options = {
-    'collapse_navigation': False
-}
+html_theme_options = {"collapse_navigation": False}
 html_context = {
     "conf_py_path": "/docs/source/",
     "display_github": True,
@@ -93,11 +95,12 @@ html_context = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
-html_css_files = ['theme_overrides.css']
+html_css_files = ["theme_overrides.css"]
 
 # Sidebars
 
-html_sidebars = { '**': ['globaltoc.html', 'relations.html',
-                         'sourcelink.html', 'searchbox.html'] }
+html_sidebars = {
+    "**": ["globaltoc.html", "relations.html", "sourcelink.html", "searchbox.html"]
+}

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,4 +1,4 @@
-sphinx ~= 7.2
 jinja2 == 3.1.6
-sphinx-rtd-theme == 1.3.0
+sphinx ~= 8.1.3
+sphinx-rtd-theme ~= 3.0.2
 sphinx_toolbox == 3.9.0


### PR DESCRIPTION
[Link to the corresponding Issue.](https://github.com/ga4gh/cat-vrs/issues/184)

This Pull Request is for [Issue 184](https://github.com/ga4gh/cat-vrs/issues/184), and mimics [this open Pull Request in the VRS Repo](https://github.com/ga4gh/vrs/pull/673) by @jsstevenson. In [Pull Request 182](https://github.com/ga4gh/cat-vrs/pull/182), @DanielPuthawala noticed that the copyright at the bottom of the readthedocs was out of date and James referenced us to the VRS pull Request. Here, I've made the same changes as James proposed in the VRS repo and also updated the copyright text to align with what is used for VRS and the VA-Spec readthedocs. It now reads as, "Copyright 2023-%Y, GA4GH CatVRS Contributors." instead of "Copyright 2023, GA4GH CatVar Study Group.". 

Pull Request checklist:
- [x] Does the title of this Pull Request reference the corresponding Issue?
- [x] Is the branch validating against pre-commit hooks? Run `pre-commit run --all-files` from the root directory.
- [x] Is the branch passing tests? Run `pytest tests/` from the root directory.

If the schema or examples were contributed to: 
- Neither the schema nor examples were contributed to in this Pull Request.
