### PR TITLE
#190 Docs: remove disclaimer

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,21 +9,6 @@ The specification consists of a JSON Schema for representing classes of categori
 conventions to maximize the utility of the schema, and a python implementation that promotes
 adoption of the standard.
 
-
-Disclaimers
-@@@@@@@@@@@
-
-
-This repository is maintained by the GA4GH Categorical Variation Working Group.  We are
-actively developing Cat-VRS, so much of the information contained herein is in an early
-state of development and should be treated as tentative and liable to change.
-
-As such, the contents of this repository represents a very early draft version of Cat-VRS.
-First, this means that the schemas contained herein are not yet an officially-released
-version of the specification.  Second, this means that the spec is expected to undergo
-frequent and potentially breaking updates until a more stable trial version is released.
-Caveat emptor.
-
 .. toctree::
    :maxdepth: 2
    :includehidden:
@@ -36,8 +21,6 @@ Caveat emptor.
    releases/index
    roadmap/index
    appendices/index
-
-
 
 .. image:: images/cat-vrs-transparent-bg.png
     :width: 50%


### PR DESCRIPTION
[#190 Docs: Remove disclaimer from readthedocs homepage](https://github.com/ga4gh/cat-vrs/issues/190)

This Pull Request removes the Disclaimer from the readthedocs homepage. They provide a warning that the spec is in early development and is anticipated to change frequently. However, this is out of date since we have had our 1.0 release.

Pull Request checklist:
- [x] Does the title of this Pull Request reference the corresponding Issue?
- [x] Is the branch validating against pre-commit hooks? Run `pre-commit run --all-files` from the root directory.
- [x] Is the branch passing tests? Run `pytest tests/` from the root directory.

If the schema or examples were contributed to:
- Neither the schema nor examples were contributed to.