### PR TITLE
Issue 197: Removed duplicate requirements.txt files

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,4 +14,4 @@ sphinx:
 
 python:
   install:
-    - requirements: docs/source/requirements.txt
+    - requirements: .requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.12"
 
 submodules:
   include: all

--- a/.requirements.txt
+++ b/.requirements.txt
@@ -1,8 +1,15 @@
+# Schema validation
+ga4gh.gks.metaschema == 0.3.2
+jsonschema
+pyyaml
+referencing
+
+# Development and testing
 pytest
+pre-commit
+
+# ReadtheDocs
+jinja2 == 3.1.6
 sphinx ~= 8.1.3
 sphinx-rtd-theme ~= 3.0.2
-pyyaml
-ga4gh.gks.metaschema==0.3.2
-jsonschema
-referencing
-pre-commit
+sphinx_toolbox == 3.9.0

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,4 +1,0 @@
-jinja2 == 3.1.6
-sphinx ~= 8.1.3
-sphinx-rtd-theme ~= 3.0.2
-sphinx_toolbox == 3.9.0


### PR DESCRIPTION
This is the corresponding Pull Request for [Issue #197: Remove duplicate requirements files](https://github.com/ga4gh/cat-vrs/issues/197). 

Here, we revised the repository to no longer have a separate requirements.txt file for ReadtheDocs. Requirements were merged into the root directory's requirements.txt, headers were added, and the ReadtheDocs configuration now points to the requirements file in the root directory. We also updated ReadtheDocs to use Python 3.12 to align with the rest of the repository.

Pull Request checklist:
- [x] Does the title of this Pull Request reference the corresponding Issue?
- [x] Is the branch validating against pre-commit hooks? Run `pre-commit run --all-files` from the root directory.
- [x] Is the branch passing tests? Run `pytest tests/` from the root directory.

If the schema or examples were contributed to:
- [x] Were the schema def/ and json/ files recompiled and committed? Run `cd schema; make all` from the root directory. **Not applicable**.
- [x] If constraints or recipes were added, have they been added to the readthedocs? To do so, you can revise the appropriate file within `docs/source/concepts/`. **Not applicable**.
- [x] Has documentation been regenerated and committed? Run `cd docs; make clean watch &` from the root directory to compile documentation.
- [x] Have tests been created or updated? **Not applicable**.
