### PR TITLE
feat: update vrs refs to 2.1.0-snapshot.2026-02.2

### DIFF
--- a/schema/cat-vrs/cat-vrs-source.yaml
+++ b/schema/cat-vrs/cat-vrs-source.yaml
@@ -10,7 +10,7 @@ imports:
 
 namespaces:
   gks.core: /ga4gh/schema/gks-core/1.1.0/json/
-  vrs: /ga4gh/schema/vrs/2.1.0-snapshot.2026-02.1/json/
+  vrs: /ga4gh/schema/vrs/2.1.0-snapshot.2026-02.2/json/
 
 $defs:
 

--- a/schema/cat-vrs/examples-source.yaml
+++ b/schema/cat-vrs/examples-source.yaml
@@ -8,7 +8,7 @@ imports:
 
 namespaces:
   gks.core: /ga4gh/schema/gks-core/1.1.0/json/
-  vrs: /ga4gh/schema/vrs/2.1.0-snapshot.2026-02.1/json/
+  vrs: /ga4gh/schema/vrs/2.1.0-snapshot.2026-02.2/json/
 
 $defs:
   example_canonicalAllele-ex1:

--- a/schema/cat-vrs/json/CategoricalVariant
+++ b/schema/cat-vrs/json/CategoricalVariant
@@ -53,7 +53,7 @@
                   "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
                },
                {
-                  "$ref": "/ga4gh/schema/vrs/2.1.0-snapshot.2026-02.1/json/Variation"
+                  "$ref": "/ga4gh/schema/vrs/2.1.0-snapshot.2026-02.2/json/Variation"
                }
             ]
          }

--- a/schema/cat-vrs/json/CopyCountConstraint
+++ b/schema/cat-vrs/json/CopyCountConstraint
@@ -16,7 +16,7 @@
          "description": "The precise value or range of copies members of this categorical variant must satisfy.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-snapshot.2026-02.1/json/Range"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-snapshot.2026-02.2/json/Range"
             },
             {
                "type": "integer"

--- a/schema/cat-vrs/json/DefiningAlleleConstraint
+++ b/schema/cat-vrs/json/DefiningAlleleConstraint
@@ -18,7 +18,7 @@
                "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-snapshot.2026-02.1/json/Allele"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-snapshot.2026-02.2/json/Allele"
             }
          ]
       },

--- a/schema/cat-vrs/json/DefiningLocationConstraint
+++ b/schema/cat-vrs/json/DefiningLocationConstraint
@@ -18,7 +18,7 @@
                "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-snapshot.2026-02.1/json/SequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-snapshot.2026-02.2/json/SequenceLocation"
             }
          ]
       },

--- a/schema/cat-vrs/recipes-source.yaml
+++ b/schema/cat-vrs/recipes-source.yaml
@@ -8,7 +8,7 @@ imports:
 
 namespaces:
   gks.core: /ga4gh/schema/gks-core/1.1.0/json/
-  vrs: /ga4gh/schema/vrs/2.1.0-snapshot.2026-02.1/json/
+  vrs: /ga4gh/schema/vrs/2.1.0-snapshot.2026-02.2/json/
 
 $defs:
   ProteinSequenceConsequence:


### PR DESCRIPTION
Link to the corresponding Issue.

N/A (sorry, didn't make one since it's a small thing)

Summary of the Pull Request.

There were some bugs in the VRS snapshot (see https://github.com/ga4gh/vrs/releases/tag/2.1.0-snapshot.2026-02.2)

Pull Request checklist:
- [ ] Does the title of this Pull Request reference the corresponding Issue?
- [x] Is the branch validating against pre-commit hooks? Run `pre-commit run --all-files` from the root directory.
- [x] Is the branch passing tests? Run `pytest tests/` from the root directory.

If the schema or examples were contributed to:
- [x] Were the schema def/ and json/ files recompiled and committed? Run `cd schema; make all` from the root directory.
- [ ] If constraints or recipes were added, have they been added to the readthedocs? To do so, you can revise the appropriate file within `docs/source/concepts/`.
- [ ] Has documentation been regenerated and committed? Run `cd docs; make clean watch &` from the root directory to compile documentation.
- [ ] Have tests been created or updated?
