### PR TITLE
fix: use correct img.shields.io link for docs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Categorical Variation Representation Specification (Cat-VRS)
 
-[![Read the Docs](https://img.shields.io/readthedocs/vr-spec/1.1)](https://cat-vrs.readthedocs.io/en/latest/)
+[![Read the Docs](https://img.shields.io/readthedocs/cat-vrs)](https://cat-vrs.readthedocs.io/en/latest/)
 
 **Cat-VRS 1.0.0 Trial Use Review November 2024 - join in [here](https://github.com/ga4gh/cat-vrs/discussions/86)**!
 


### PR DESCRIPTION
## Before
<img width="905" height="97" alt="Screenshot 2026-02-12 at 19 36 11" src="https://github.com/user-attachments/assets/9f86f6fe-98c9-4a05-bd4a-606af7e2e9d2" />


## After
<img width="905" height="97" alt="Screenshot 2026-02-12 at 19 35 46" src="https://github.com/user-attachments/assets/2420a40b-4d91-4991-9925-d70dd450f701" />
