### PR TITLE
#208: add description for type in Constraint.heritableProperties

### DIFF
--- a/schema/cat-vrs/cat-vrs-source.yaml
+++ b/schema/cat-vrs/cat-vrs-source.yaml
@@ -77,6 +77,8 @@ $defs:
     heritableProperties:
       type:
         type: string
+        description: >-
+          MUST be set to the name of the concrete Constraint subtype.
     heritableRequired:
       - type
 


### PR DESCRIPTION
Fixes #208

## Summary of the Pull Request

This PR adds a missing `description` field to the `type` property under `Constraint.heritableProperties` in `schema/cat-vrs/cat-vrs-source.yaml`.

This is a documentation-only change. No structural schema definitions or validation behavior were modified.