### PR TITLE
#205: add GKS Think Tank information to Getting Involved page

### DIFF
--- a/docs/source/getting_involved.rst
+++ b/docs/source/getting_involved.rst
@@ -16,6 +16,8 @@ can get involved:
 
 * Join the `#GKS-categorical-variation channel <https://ga4gh.slack.com/archives/C05UKK8DML7>`_ on GA4GH's Slack.
 
+* Participate in the GA4GH Genomic Knowledge Standards (GKS) Work Stream Think Tank meetings, where Cat-VRS issues and specification topics are often discussed. Information about GKS and participation opportunities is available on the `Genomic Knowledge Standards Work Stream page <https://www.ga4gh.org/work_stream/genomic-knowledge-standards/>`_.
+
 * Read the machine readable schema definitions, participate in Discussions, and raise Issues in the `Cat-VRS GitHub repository <https://github.com/ga4gh/cat-vrs>`_.
 
 


### PR DESCRIPTION
Adds information about participation in GKS Think Tank meetings to the Getting Involved page, as requested in issue #205.