### PR TITLE
#212: Updated hardcoded github_version in docs/source/conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,7 @@ master_doc = "index"
 release = _get_git_tag()
 version = _parse_release_as_version(release)
 # Automatically use the RTD branch/tag as the GitHub version
-github_version = os.environ.get("READTHEDOCS_VERSION", "main")
+github_version = os.environ.get("READTHEDOCS_GIT_IDENTIFIER", "main")
 
 # -- Schema doc paths --------------------------------------------------------
 


### PR DESCRIPTION
## Link to the corresponding Issue
[#212 readthedocs "Edit on GitHub" link not working for latest and stable branches](https://github.com/ga4gh/cat-vrs/issues/212)

## Summary of the Pull Request
@larrybabb noticed that the "Edit on GitHub" hyperlink in the header of the readthedocs page was broken. This seems to only be the case for the `latest` and `stable` versions of the readthedocs site, with readthedocs interpreting both `latest` and `stable` as branch names. 

The `github_version` variable from the docs/source/conf.py was updated to correctly generate the appropriate path for these two readthedocs versions.

## Pull Request checklist

### Required
- [x] The title of this Pull Request accurately reflects the scope and content of the linked Issue.
- [x] The branch passes all pre-commit hooks (Run `pre-commit run --all-files` from the root directory).
- [x] The branch passes all tests (Run `pytest tests/` from the root directory).

### Required if the schema or examples were contributed to
- [ ] The schema `def/` and `json/` files have been recompiled and committed (Run `cd schema; make all` from the root directory).
- [ ] Tests have been created or updated.
- [ ] Schema changes have been documented (existing files updated or new files created in `docs/source/`).
- [ ] Any new schema definition `.rst` files have been registered in the documentation structure.
- [ ] Documentation has been regenerated and committed (Run `cd docs; make clean watch &` from the root directory to compile documentation).
