### PR TITLE
#212: Update github_version for "stable" readthedocs version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,12 @@ def _parse_release_as_version(rls):
 
 
 # -- Project information -----------------------------------------------------
+print("RTD env:", {
+    "RTD_VERSION": os.environ.get("READTHEDOCS_VERSION"),
+    "RTD_VERSION_TYPE": os.environ.get("READTHEDOCS_VERSION_TYPE"),
+    "RTD_GIT_IDENTIFIER": os.environ.get("READTHEDOCS_GIT_IDENTIFIER"),
+    "RTD_GIT_COMMIT_HASH": os.environ.get("READTHEDOCS_GIT_COMMIT_HASH")
+})
 
 project = "GA4GH Categorical Variation Representation Specification"
 copyright = "2023-%Y, GA4GH CatVRS Contributors."
@@ -47,8 +53,20 @@ master_doc = "index"
 # N.B. RTD ignores these values. :-/
 release = _get_git_tag()
 version = _parse_release_as_version(release)
-# Automatically use the RTD branch/tag as the GitHub version
-github_version = os.environ.get("READTHEDOCS_GIT_IDENTIFIER", "main")
+
+# Generate GitHub version depending on the Readthedocs Version
+# - stable: will use the tag name
+# - latest: will use the corresponding branch name
+# - other branch versions: will use the branch name
+# - PR previews: will use the commit hash
+if os.environ.get("READTHEDOCS"):
+    identifier = os.environ.get("READTHEDOCS_GIT_IDENTIFIER")
+    if identifier and identifier.isdigit():
+        github_version = os.environ.get("READTHEDOCS_GIT_COMMIT_HASH", "main")
+    else:
+        github_version = identifier or os.environ.get("READTHEDOCS_GIT_COMMIT_HASH", "main")
+else:
+    github_version = "main"
 
 # -- Schema doc paths --------------------------------------------------------
 


### PR DESCRIPTION
## Link to the corresponding Issue
[#212 readthedocs "Edit on GitHub" link not working for latest and stable branches](https://github.com/ga4gh/cat-vrs/issues/212)

## Summary of the Pull Request
Larry noticed that the "Edit on GitHub" hyperlink in the header of the readthedocs page was broken. This seems to only be the case for the `latest` and `stable` versions of the readthedocs site, with readthedocs interpreting both `latest` and `stable` as branch names. 

The `github_version` variable from the docs/source/conf.py was updated to correctly generate the appropriate path for these two readthedocs versions in [Pull Request #213](https://github.com/ga4gh/cat-vrs/pull/213), but this only resolved the case of `latest`. Here, I try a fix that will result in the following behavior:
- stable: will use tag name
- latest: will use branch name
- other branch versions: will use branch name
- PR previews: will use commit hash

Unfortunately, likewise with #213, this cannot be tested without merging the PR.

## Pull Request checklist
### Required
- [x] The title of this Pull Request accurately reflects the scope and content of the linked Issue.
- [x] The branch passes all pre-commit hooks (Run `pre-commit run --all-files` from the root directory).
- [x] The branch passes all tests (Run `pytest tests/` from the root directory).

### Required if the schema or examples were contributed to
- [ ] The schema `def/` and `json/` files have been recompiled and committed (Run `cd schema; make all` from the root directory).
- [ ] Tests have been created or updated.
- [ ] Schema changes have been documented (existing files updated or new files created in `docs/source/`).
- [ ] Any new schema definition `.rst` files have been registered in the documentation structure.
- [ ] Documentation has been regenerated and committed (Run `cd docs; make clean watch &` from the root directory to compile documentation).
