### PR TITLE
fix: correct TP53 example errors in conceptType and primaryCoding

### DIFF
--- a/examples/tp53-copy-loss.annotated.yaml
+++ b/examples/tp53-copy-loss.annotated.yaml
@@ -92,7 +92,7 @@ constraints:
       name: TP53
 
       # The type of feature being denoted: gene, pseudogene, sequence, region, etc
-      conceptType: gene
+      conceptType: Gene
 
       # A primary coding for the concept.
       # A coding is structured representation of a code for a defined concept in a terminology or code system.

--- a/schema/cat-vrs/examples-source.yaml
+++ b/schema/cat-vrs/examples-source.yaml
@@ -900,14 +900,14 @@ $defs:
         featureContext:
           id: TP53
           name: TP53
-          conceptType: gene
+          conceptType: Gene
           primaryCoding:
-            - id: hgnc:11998
-              name: TP53
-              system: https://genenames.org
-              code: HGNC:11998
-              iris:
-                - https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:11998
+            id: hgnc:11998
+            name: TP53
+            system: https://genenames.org
+            code: HGNC:11998
+            iris:
+              - https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:11998
           extensions:
             - name: cytogenetic location
               value: 17p13.1


### PR DESCRIPTION
## Summary

Fixes the two errors reported in #220 for the TP53 `FeatureContextConstraint` example:

1. **`conceptType` case error**: Changed `gene` to `Gene` in `tp53-copy-loss.annotated.yaml` (line 95) to match the convention used consistently in all other example files
2. **`primaryCoding` structure error**: Changed `primaryCoding` from list format (with `-` prefix) to object format in `examples-source.yaml`, matching the schema definition and all other examples

### Files changed
- `examples/tp53-copy-loss.annotated.yaml` — fix `conceptType: gene` → `Gene`
- `schema/cat-vrs/examples-source.yaml` — fix `conceptType: gene` → `Gene` and `primaryCoding` list → object

Resolves #220