### PR TITLE
fix: prep 1.1.0-snapshot.2026-02.3 release (fix cat-vrs refs)

### DIFF
--- a/schema/cat-vrs/cat-vrs-source.yaml
+++ b/schema/cat-vrs/cat-vrs-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/cat-vrs-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/cat-vrs-source.yaml"
 title: GA4GH-Cat-VRS-Definitions
 type: object
 strict: true

--- a/schema/cat-vrs/examples-source.yaml
+++ b/schema/cat-vrs/examples-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/examples-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/examples-source.yaml"
 title: GA4GH-Cat-VRS-examples
 type: object
 

--- a/schema/cat-vrs/json/CanonicalAllele
+++ b/schema/cat-vrs/json/CanonicalAllele
@@ -7,7 +7,7 @@
    "description": "A canonical allele is defined by an Allele that is representative of a collection of congruent Alleles, each of which depict the same nucleic acid on different underlying reference sequences. Congruent representations of an Allele often exist across different genome assemblies and associated cDNA transcript representations.",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/CategoricalVariant"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/CategoricalVariant"
       },
       {
          "properties": {
@@ -17,7 +17,7 @@
                "contains": {
                   "allOf": [
                      {
-                        "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/DefiningAlleleConstraint"
+                        "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/DefiningAlleleConstraint"
                      },
                      {
                         "type": "object",

--- a/schema/cat-vrs/json/CategoricalCnv
+++ b/schema/cat-vrs/json/CategoricalCnv
@@ -7,7 +7,7 @@
    "description": "A representation of the constraints for matching knowledge about CNVs.",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/CategoricalVariant"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/CategoricalVariant"
       },
       {
          "properties": {
@@ -20,7 +20,7 @@
                      "contains": {
                         "allOf": [
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/DefiningLocationConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/DefiningLocationConstraint"
                            },
                            {
                               "properties": {
@@ -47,10 +47,10 @@
                      "contains": {
                         "oneOf": [
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/CopyCountConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/CopyCountConstraint"
                            },
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/CopyChangeConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/CopyChangeConstraint"
                            }
                         ]
                      }

--- a/schema/cat-vrs/json/CategoricalVariant
+++ b/schema/cat-vrs/json/CategoricalVariant
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/CategoricalVariant",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/CategoricalVariant",
    "title": "CategoricalVariant",
    "type": "object",
    "maturity": "trial use",
@@ -64,22 +64,22 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/CopyChangeConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/CopyChangeConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/CopyCountConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/CopyCountConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/DefiningAlleleConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/DefiningAlleleConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/DefiningLocationConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/DefiningLocationConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/FeatureContextConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/FeatureContextConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/FunctionConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/FunctionConstraint"
                }
             ]
          }

--- a/schema/cat-vrs/json/Constraint
+++ b/schema/cat-vrs/json/Constraint
@@ -1,28 +1,28 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/Constraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/Constraint",
    "title": "Constraint",
    "type": "object",
    "maturity": "trial use",
    "description": "Constraints are used to construct an intensional semantics of categorical variant types.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/CopyChangeConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/CopyChangeConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/CopyCountConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/CopyCountConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/DefiningAlleleConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/DefiningAlleleConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/DefiningLocationConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/DefiningLocationConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/FeatureContextConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/FeatureContextConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/FunctionConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/FunctionConstraint"
       }
    ]
 }

--- a/schema/cat-vrs/json/CopyChangeConstraint
+++ b/schema/cat-vrs/json/CopyChangeConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/CopyChangeConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/CopyChangeConstraint",
    "title": "CopyChangeConstraint",
    "type": "object",
    "maturity": "draft",

--- a/schema/cat-vrs/json/CopyCountConstraint
+++ b/schema/cat-vrs/json/CopyCountConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/CopyCountConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/CopyCountConstraint",
    "title": "CopyCountConstraint",
    "type": "object",
    "maturity": "trial use",

--- a/schema/cat-vrs/json/DefiningAlleleConstraint
+++ b/schema/cat-vrs/json/DefiningAlleleConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/DefiningAlleleConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/DefiningAlleleConstraint",
    "title": "DefiningAlleleConstraint",
    "type": "object",
    "maturity": "trial use",

--- a/schema/cat-vrs/json/DefiningLocationConstraint
+++ b/schema/cat-vrs/json/DefiningLocationConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/DefiningLocationConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/DefiningLocationConstraint",
    "title": "DefiningLocationConstraint",
    "type": "object",
    "maturity": "trial use",

--- a/schema/cat-vrs/json/FeatureContextConstraint
+++ b/schema/cat-vrs/json/FeatureContextConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/FeatureContextConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/FeatureContextConstraint",
    "title": "FeatureContextConstraint",
    "type": "object",
    "maturity": "draft",

--- a/schema/cat-vrs/json/FunctionConstraint
+++ b/schema/cat-vrs/json/FunctionConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/FunctionConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/FunctionConstraint",
    "title": "FunctionConstraint",
    "type": "object",
    "maturity": "draft",

--- a/schema/cat-vrs/json/FunctionVariant
+++ b/schema/cat-vrs/json/FunctionVariant
@@ -7,7 +7,7 @@
    "description": "A representation of the constraints for matching knowledge about function variants; e.g., gain-of-function or loss-of-function.",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/CategoricalVariant"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/CategoricalVariant"
       },
       {
          "properties": {
@@ -19,7 +19,7 @@
                      "contains": {
                         "allOf": [
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/FunctionConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/FunctionConstraint"
                            }
                         ]
                      }
@@ -28,13 +28,13 @@
                      "contains": {
                         "anyOf": [
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/DefiningAlleleConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/DefiningAlleleConstraint"
                            },
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/DefiningLocationConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/DefiningLocationConstraint"
                            },
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/FeatureContextConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/FeatureContextConstraint"
                            }
                         ]
                      }

--- a/schema/cat-vrs/json/ProteinSequenceConsequence
+++ b/schema/cat-vrs/json/ProteinSequenceConsequence
@@ -7,7 +7,7 @@
    "description": "A change that occurs in a protein sequence as a result of genomic changes. Due to the degenerate nature of the genetic code, there are often several genomic changes that can cause a protein sequence consequence. The protein sequence consequence, like a CanonicalAllele, is defined by an Allele that is representative of a collection of congruent Protein Alleles that share the same altered codon(s).",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/CategoricalVariant"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/CategoricalVariant"
       },
       {
          "properties": {
@@ -15,7 +15,7 @@
                "contains": {
                   "allOf": [
                      {
-                        "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/DefiningAlleleConstraint"
+                        "$ref": "/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/DefiningAlleleConstraint"
                      },
                      {
                         "type": "object",

--- a/schema/cat-vrs/json/example_braf-v600
+++ b/schema/cat-vrs/json/example_braf-v600
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/example_braf-v600",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/example_braf-v600",
    "title": "example_braf-v600",
    "type": "CategoricalVariant",
    "id": "civic.vid:17",

--- a/schema/cat-vrs/json/example_canonicalAllele-ex1
+++ b/schema/cat-vrs/json/example_canonicalAllele-ex1
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/example_canonicalAllele-ex1",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/example_canonicalAllele-ex1",
    "title": "example_canonicalAllele-ex1",
    "type": "CategoricalVariant",
    "id": "clinvar:662001",

--- a/schema/cat-vrs/json/example_canonicalAllele-ex2
+++ b/schema/cat-vrs/json/example_canonicalAllele-ex2
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/example_canonicalAllele-ex2",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/example_canonicalAllele-ex2",
    "title": "example_canonicalAllele-ex2",
    "type": "CategoricalVariant",
    "id": "clingen:CA415424538",

--- a/schema/cat-vrs/json/example_categoricalCnv-ex1
+++ b/schema/cat-vrs/json/example_categoricalCnv-ex1
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/example_categoricalCnv-ex1",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/example_categoricalCnv-ex1",
    "title": "example_categoricalCnv-ex1",
    "type": "CategoricalVariant",
    "id": "clinvar:151061",

--- a/schema/cat-vrs/json/example_categoricalCnv-ex2
+++ b/schema/cat-vrs/json/example_categoricalCnv-ex2
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/example_categoricalCnv-ex2",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/example_categoricalCnv-ex2",
    "title": "example_categoricalCnv-ex2",
    "type": "CategoricalVariant",
    "id": "clinvar:151061",

--- a/schema/cat-vrs/json/example_categoricalCnv-ex3
+++ b/schema/cat-vrs/json/example_categoricalCnv-ex3
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/example_categoricalCnv-ex3",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/example_categoricalCnv-ex3",
    "title": "example_categoricalCnv-ex3",
    "type": "CategoricalVariant",
    "id": "clingen:cacn42032202",

--- a/schema/cat-vrs/json/example_describedVariant-ex1
+++ b/schema/cat-vrs/json/example_describedVariant-ex1
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/example_describedVariant-ex1",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/example_describedVariant-ex1",
    "title": "example_describedVariant-ex1",
    "type": "CategoricalVariant",
    "id": "clinvar:1177130",

--- a/schema/cat-vrs/json/example_functionVariant-ex1
+++ b/schema/cat-vrs/json/example_functionVariant-ex1
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/example_functionVariant-ex1",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/example_functionVariant-ex1",
    "title": "example_functionVariant-ex1",
    "type": "CategoricalVariant",
    "id": "civic.mpid:4428",

--- a/schema/cat-vrs/json/example_functionVariant-ex2
+++ b/schema/cat-vrs/json/example_functionVariant-ex2
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/example_functionVariant-ex2",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/example_functionVariant-ex2",
    "title": "example_functionVariant-ex2",
    "type": "CategoricalVariant",
    "id": "civic.mpid:186",

--- a/schema/cat-vrs/json/example_functionVariant-ex3
+++ b/schema/cat-vrs/json/example_functionVariant-ex3
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/example_functionVariant-ex3",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/example_functionVariant-ex3",
    "title": "example_functionVariant-ex3",
    "type": "CategoricalVariant",
    "id": "civic.mpid:1150",

--- a/schema/cat-vrs/json/example_proteinSequenceConsequence-ex1
+++ b/schema/cat-vrs/json/example_proteinSequenceConsequence-ex1
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/example_proteinSequenceConsequence-ex1",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/example_proteinSequenceConsequence-ex1",
    "title": "example_proteinSequenceConsequence-ex1",
    "type": "CategoricalVariant",
    "id": "civic.mpid:33",

--- a/schema/cat-vrs/json/example_proteinSequenceConsequence-ex2
+++ b/schema/cat-vrs/json/example_proteinSequenceConsequence-ex2
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/example_proteinSequenceConsequence-ex2",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/example_proteinSequenceConsequence-ex2",
    "title": "example_proteinSequenceConsequence-ex2",
    "type": "CategoricalVariant",
    "id": "clinvar:55628",

--- a/schema/cat-vrs/json/example_tp53-copy-loss
+++ b/schema/cat-vrs/json/example_tp53-copy-loss
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.1/json/example_tp53-copy-loss",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-snapshot.2026-02.3/json/example_tp53-copy-loss",
    "title": "example_tp53-copy-loss",
    "type": "CategoricalVariant",
    "id": "civic.vid:4452",


### PR DESCRIPTION
## Link to the corresponding Issue

N/A

## Summary of the Pull Request

I noticed that in [1.1.0-snapshot.2026-02.2](https://github.com/ga4gh/cat-vrs/releases/tag/1.1.0-snapshot.2026-02.2) release I forgot to update the Cat-VRS refs (maybe we should add this to the template for preparing releases?). This PR updates the cat-vrs refs for the next patch release 1.1.0-snapshot.2026-02.3

## Pull Request checklist

### Required

- [X] The title of this Pull Request accurately reflects the scope and content of the linked Issue.
- [X] The branch passes all pre-commit hooks (Run `pre-commit run --all-files` from the root directory).
- [X] The branch passes all tests (Run `pytest tests/` from the root directory).

### Required if the schema or examples were contributed to

- [X] The schema `def/` and `json/` files have been recompiled and committed (Run `cd schema; make all` from the root directory).
- [ ] Examples `json/` files have been compiled and committed (Run `cd examples; make all` from the root directory).
    N/A
- [ ] Tests have been created or updated.
    N/A
- [ ] Schema changes have been documented (existing files updated or new files created in `docs/source/`).
    N/A
- [ ] Any new schema definition `.rst` files have been registered in the documentation structure.
    N/A
- [X] Documentation has been regenerated and committed (Run `cd docs; make clean watch &` from the root directory to compile documentation).
