### PR TITLE
Bump to 1.1.0-ballot.2026-07.1 and align examples with new MappableCo…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "submodules/vrs"]
 	path = submodules/vrs
 	url = https://github.com/ga4gh/vrs.git
-	branch = v2
+	branch = 2.1.0-ballot.2026-07

--- a/examples/json/adjacencyFusion-ex1.json
+++ b/examples/json/adjacencyFusion-ex1.json
@@ -41,6 +41,7 @@
       "orderKnown": true,
       "adjoinedElements": [
         {
+          "type": "MappableConcept",
           "id": "ncbi:613",
           "conceptType": "Gene",
           "name": "BCR",
@@ -55,6 +56,7 @@
           }
         },
         {
+          "type": "MappableConcept",
           "id": "ncbi:25",
           "conceptType": "Gene",
           "name": "ABL1",

--- a/examples/json/adjacencyFusion-ex2.json
+++ b/examples/json/adjacencyFusion-ex2.json
@@ -16,6 +16,7 @@
           "type": "UnspecifiedElement"
         },
         {
+          "type": "MappableConcept",
           "id": "hgnc:8031",
           "conceptType": "Gene",
           "name": "NTRK1",
@@ -41,6 +42,7 @@
         "membershipOperator": "OR",
         "concepts": [
           {
+            "type": "MappableConcept",
             "id": "hgnc:6636",
             "conceptType": "Gene",
             "name": "LMNA",
@@ -55,6 +57,7 @@
             }
           },
           {
+            "type": "MappableConcept",
             "id": "hgnc:11758",
             "conceptType": "Gene",
             "name": "TFG",
@@ -69,6 +72,7 @@
             }
           },
           {
+            "type": "MappableConcept",
             "id": "hgnc:11998",
             "conceptType": "Gene",
             "name": "TP53",
@@ -83,6 +87,7 @@
             }
           },
           {
+            "type": "MappableConcept",
             "id": "hgnc:12012",
             "conceptType": "Gene",
             "name": "TPM3",
@@ -97,6 +102,7 @@
             }
           },
           {
+            "type": "MappableConcept",
             "id": "hgnc:12017",
             "conceptType": "Gene",
             "name": "TPR",

--- a/examples/json/adjacencyFusion-ex3.json
+++ b/examples/json/adjacencyFusion-ex3.json
@@ -16,6 +16,7 @@
           "type": "UnspecifiedElement"
         },
         {
+          "type": "MappableConcept",
           "id": "ncbi:171017",
           "conceptType": "Gene",
           "name": "ZNF384",

--- a/examples/json/adjacencyFusion-ex4.json
+++ b/examples/json/adjacencyFusion-ex4.json
@@ -13,6 +13,7 @@
       "orderKnown": true,
       "adjoinedElements": [
         {
+          "type": "MappableConcept",
           "id": "hgnc:3689",
           "conceptType": "Gene",
           "name": "FGFR2",

--- a/examples/json/braf-v600.annotated.json
+++ b/examples/json/braf-v600.annotated.json
@@ -48,6 +48,7 @@
       },
       "relations": [
         {
+          "type": "MappableConcept",
           "primaryCoding": {
             "code": "translation_of",
             "system": "http://www.sequenceontology.org",
@@ -58,6 +59,7 @@
         }
       ],
       "matchCharacteristic": {
+        "type": "MappableConcept",
         "primaryCoding": {
           "code": "is_within",
           "system": "ga4gh-gks-term:location-match"

--- a/examples/json/braf-v600.json
+++ b/examples/json/braf-v600.json
@@ -48,6 +48,7 @@
       },
       "relations": [
         {
+          "type": "MappableConcept",
           "primaryCoding": {
             "code": "translation_of",
             "system": "http://www.sequenceontology.org",
@@ -58,6 +59,7 @@
         }
       ],
       "matchCharacteristic": {
+        "type": "MappableConcept",
         "primaryCoding": {
           "code": "is_within",
           "system": "ga4gh-gks-term:location-match"

--- a/examples/json/canonicalAllele-ex1.json
+++ b/examples/json/canonicalAllele-ex1.json
@@ -151,12 +151,14 @@
       },
       "relations": [
         {
+          "type": "MappableConcept",
           "primaryCoding": {
             "code": "liftover_to",
             "system": "ga4gh-gks-term:allele-relation"
           }
         },
         {
+          "type": "MappableConcept",
           "primaryCoding": {
             "code": "transcribed_to",
             "system": "http://www.sequenceontology.org",

--- a/examples/json/canonicalAllele-ex2.json
+++ b/examples/json/canonicalAllele-ex2.json
@@ -91,12 +91,14 @@
       },
       "relations": [
         {
+          "type": "MappableConcept",
           "primaryCoding": {
             "code": "liftover_to",
             "system": "ga4gh-gks-term:allele-relation"
           }
         },
         {
+          "type": "MappableConcept",
           "primaryCoding": {
             "code": "transcribed_to",
             "system": "http://www.sequenceontology.org",

--- a/examples/json/categoricalCnv-ex1.json
+++ b/examples/json/categoricalCnv-ex1.json
@@ -84,6 +84,7 @@
       },
       "relations": [
         {
+          "type": "MappableConcept",
           "primaryCoding": {
             "code": "liftover_to",
             "system": "ga4gh-gks-term:allele-relation"
@@ -91,6 +92,7 @@
         }
       ],
       "matchCharacteristic": {
+        "type": "MappableConcept",
         "primaryCoding": {
           "code": "is_within",
           "system": "ga4gh-gks-term:location-match"

--- a/examples/json/categoricalCnv-ex2.json
+++ b/examples/json/categoricalCnv-ex2.json
@@ -85,6 +85,7 @@
       },
       "relations": [
         {
+          "type": "MappableConcept",
           "primaryCoding": {
             "code": "liftover_to",
             "system": "ga4gh-gks-term:allele-relation"
@@ -92,6 +93,7 @@
         }
       ],
       "matchCharacteristic": {
+        "type": "MappableConcept",
         "primaryCoding": {
           "code": "is_within",
           "system": "ga4gh-gks-term:location-match"

--- a/examples/json/categoricalCnv-ex3.json
+++ b/examples/json/categoricalCnv-ex3.json
@@ -61,6 +61,7 @@
       },
       "relations": [
         {
+          "type": "MappableConcept",
           "primaryCoding": {
             "code": "liftover_to",
             "system": "ga4gh-gks-term:allele-relation"
@@ -68,6 +69,7 @@
         }
       ],
       "matchCharacteristic": {
+        "type": "MappableConcept",
         "primaryCoding": {
           "code": "is_within",
           "system": "ga4gh-gks-term:location-match"

--- a/examples/json/functionVariant-ex1.json
+++ b/examples/json/functionVariant-ex1.json
@@ -7,6 +7,7 @@
     {
       "type": "FeatureContextConstraint",
       "featureContext": {
+        "type": "MappableConcept",
         "id": "hgnc:7989",
         "conceptType": "Gene",
         "name": "NRAS",
@@ -24,6 +25,7 @@
     {
       "type": "FunctionConstraint",
       "functionConsequence": {
+        "type": "MappableConcept",
         "id": "SO:0002219",
         "name": "functionally normal",
         "primaryCoding": {

--- a/examples/json/functionVariant-ex2.json
+++ b/examples/json/functionVariant-ex2.json
@@ -7,6 +7,7 @@
     {
       "type": "FeatureContextConstraint",
       "featureContext": {
+        "type": "MappableConcept",
         "id": "hgnc:1101",
         "conceptType": "Gene",
         "name": "BRCA2",
@@ -24,6 +25,7 @@
     {
       "type": "FunctionConstraint",
       "functionConsequence": {
+        "type": "MappableConcept",
         "id": "SO:0002054",
         "name": "loss of function",
         "primaryCoding": {

--- a/examples/json/functionVariant-ex3.json
+++ b/examples/json/functionVariant-ex3.json
@@ -65,6 +65,7 @@
     {
       "type": "FeatureContextConstraint",
       "featureContext": {
+        "type": "MappableConcept",
         "id": "hgnc:8975",
         "conceptType": "Gene",
         "name": "PIK3CA",
@@ -81,6 +82,7 @@
     {
       "type": "FunctionConstraint",
       "functionConsequence": {
+        "type": "MappableConcept",
         "id": "SO:0002053",
         "name": "gain of function",
         "primaryCoding": {

--- a/examples/json/proteinSequenceConsequence-ex1.json
+++ b/examples/json/proteinSequenceConsequence-ex1.json
@@ -135,6 +135,7 @@
       },
       "relations": [
         {
+          "type": "MappableConcept",
           "primaryCoding": {
             "code": "translation_of",
             "system": "http://www.sequenceontology.org",

--- a/examples/json/proteinSequenceConsequence-ex2.json
+++ b/examples/json/proteinSequenceConsequence-ex2.json
@@ -117,6 +117,7 @@
       },
       "relations": [
         {
+          "type": "MappableConcept",
           "primaryCoding": {
             "code": "translation_of",
             "system": "http://www.sequenceontology.org",

--- a/examples/json/tp53-copy-loss.annotated.json
+++ b/examples/json/tp53-copy-loss.annotated.json
@@ -56,6 +56,7 @@
       },
       "relations": [
         {
+          "type": "MappableConcept",
           "primaryCoding": {
             "code": "liftover_to",
             "system": "ga4gh-gks-term:allele-relation"
@@ -63,6 +64,7 @@
         }
       ],
       "matchCharacteristic": {
+        "type": "MappableConcept",
         "primaryCoding": {
           "code": "is_within",
           "system": "ga4gh-gks-term:location-match"
@@ -72,6 +74,7 @@
     {
       "type": "FeatureContextConstraint",
       "featureContext": {
+        "type": "MappableConcept",
         "id": "TP53",
         "name": "TP53",
         "conceptType": "gene",

--- a/examples/json/tp53-copy-loss.json
+++ b/examples/json/tp53-copy-loss.json
@@ -55,6 +55,7 @@
       },
       "relations": [
         {
+          "type": "MappableConcept",
           "primaryCoding": {
             "code": "liftover_to",
             "system": "ga4gh-gks-term:allele-relation"
@@ -62,6 +63,7 @@
         }
       ],
       "matchCharacteristic": {
+        "type": "MappableConcept",
         "primaryCoding": {
           "code": "is_within",
           "system": "ga4gh-gks-term:location-match"
@@ -71,6 +73,7 @@
     {
       "type": "FeatureContextConstraint",
       "featureContext": {
+        "type": "MappableConcept",
         "id": "hgnc:11998",
         "name": "TP53",
         "conceptType": "Gene",

--- a/examples/yaml/adjacencyFusion-ex1.yaml
+++ b/examples/yaml/adjacencyFusion-ex1.yaml
@@ -30,7 +30,8 @@ constraints:
   - type: AdjacencyConstraint
     orderKnown: true
     adjoinedElements:
-      - id: ncbi:613
+      - type: MappableConcept
+        id: ncbi:613
         conceptType: Gene
         name: BCR
         primaryCoding:
@@ -40,7 +41,8 @@ constraints:
           code: "613"
           iris:
             - https://www.ncbi.nlm.nih.gov/gene/613
-      - id: ncbi:25
+      - type: MappableConcept
+        id: ncbi:25
         conceptType: Gene
         name: ABL1
         primaryCoding:

--- a/examples/yaml/adjacencyFusion-ex2.yaml
+++ b/examples/yaml/adjacencyFusion-ex2.yaml
@@ -10,7 +10,8 @@ constraints:
     orderKnown: false
     adjoinedElements:
       - type: UnspecifiedElement
-      - id: hgnc:8031
+      - type: MappableConcept
+        id: hgnc:8031
         conceptType: Gene
         name: NTRK1
         primaryCoding:
@@ -27,7 +28,8 @@ extensions:
       type: ConceptSet
       membershipOperator: OR
       concepts:
-        - id: hgnc:6636
+        - type: MappableConcept
+          id: hgnc:6636
           conceptType: Gene
           name: LMNA
           primaryCoding:
@@ -37,7 +39,8 @@ extensions:
             code: HGNC:6636
             iris:
               - https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:6636
-        - id: hgnc:11758
+        - type: MappableConcept
+          id: hgnc:11758
           conceptType: Gene
           name: TFG
           primaryCoding:
@@ -47,7 +50,8 @@ extensions:
             code: HGNC:11758
             iris:
               - https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:11758
-        - id: hgnc:11998
+        - type: MappableConcept
+          id: hgnc:11998
           conceptType: Gene
           name: TP53
           primaryCoding:
@@ -57,7 +61,8 @@ extensions:
             code: HGNC:11998
             iris:
               - https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:11998
-        - id: hgnc:12012
+        - type: MappableConcept
+          id: hgnc:12012
           conceptType: Gene
           name: TPM3
           primaryCoding:
@@ -67,7 +72,8 @@ extensions:
             code: HGNC:12012
             iris:
               - https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:12012
-        - id: hgnc:12017
+        - type: MappableConcept
+          id: hgnc:12017
           conceptType: Gene
           name: TPR
           primaryCoding:

--- a/examples/yaml/adjacencyFusion-ex3.yaml
+++ b/examples/yaml/adjacencyFusion-ex3.yaml
@@ -10,7 +10,8 @@ constraints:
     orderKnown: true
     adjoinedElements:
       - type: UnspecifiedElement
-      - id: ncbi:171017
+      - type: MappableConcept
+        id: ncbi:171017
         conceptType: Gene
         name: ZNF384
         primaryCoding:

--- a/examples/yaml/adjacencyFusion-ex4.yaml
+++ b/examples/yaml/adjacencyFusion-ex4.yaml
@@ -10,7 +10,8 @@ constraints:
   - type: AdjacencyConstraint
     orderKnown: true
     adjoinedElements:
-      - id: hgnc:3689
+      - type: MappableConcept
+        id: hgnc:3689
         conceptType: Gene
         name: FGFR2
         primaryCoding:

--- a/examples/yaml/braf-v600.annotated.yaml
+++ b/examples/yaml/braf-v600.annotated.yaml
@@ -77,12 +77,14 @@ constraints:
       end: 600
       sequence: V
     relations:
-      - primaryCoding:
+      - type: MappableConcept
+        primaryCoding:
           code: translation_of
           system: http://www.sequenceontology.org
           iris:
             - http://www.sequenceontology.org/browser/current_release/term/translation_of
     matchCharacteristic:
+      type: MappableConcept
       primaryCoding:
         code: is_within
         system: ga4gh-gks-term:location-match

--- a/examples/yaml/braf-v600.yaml
+++ b/examples/yaml/braf-v600.yaml
@@ -39,12 +39,14 @@ constraints:
       end: 600
       sequence: V
     relations:
-      - primaryCoding:
+      - type: MappableConcept
+        primaryCoding:
           code: translation_of
           system: http://www.sequenceontology.org
           iris:
             - http://www.sequenceontology.org/browser/current_release/term/translation_of
     matchCharacteristic:
+      type: MappableConcept
       primaryCoding:
         code: is_within
         system: ga4gh-gks-term:location-match

--- a/examples/yaml/canonicalAllele-ex1.yaml
+++ b/examples/yaml/canonicalAllele-ex1.yaml
@@ -99,10 +99,12 @@ constraints:
         sequence: ''
         repeatSubunitLength: 2
     relations:
-      - primaryCoding:
+      - type: MappableConcept
+        primaryCoding:
           code: liftover_to
           system: ga4gh-gks-term:allele-relation
-      - primaryCoding:
+      - type: MappableConcept
+        primaryCoding:
           code: transcribed_to
           system: http://www.sequenceontology.org
           iris:

--- a/examples/yaml/canonicalAllele-ex2.yaml
+++ b/examples/yaml/canonicalAllele-ex2.yaml
@@ -60,10 +60,12 @@ constraints:
         type: LiteralSequenceExpression
         sequence: G
     relations:
-      - primaryCoding:
+      - type: MappableConcept
+        primaryCoding:
           code: liftover_to
           system: ga4gh-gks-term:allele-relation
-      - primaryCoding:
+      - type: MappableConcept
+        primaryCoding:
           code: transcribed_to
           system: http://www.sequenceontology.org
           iris:

--- a/examples/yaml/categoricalCnv-ex1.yaml
+++ b/examples/yaml/categoricalCnv-ex1.yaml
@@ -54,10 +54,12 @@ constraints:
         - 6014161
         - null
     relations:
-      - primaryCoding:
+      - type: MappableConcept
+        primaryCoding:
           code: liftover_to
           system: ga4gh-gks-term:allele-relation
     matchCharacteristic:
+      type: MappableConcept
       primaryCoding:
         code: is_within
         system: ga4gh-gks-term:location-match

--- a/examples/yaml/categoricalCnv-ex2.yaml
+++ b/examples/yaml/categoricalCnv-ex2.yaml
@@ -55,10 +55,12 @@ constraints:
         - 6014161
         - null
     relations:
-      - primaryCoding:
+      - type: MappableConcept
+        primaryCoding:
           code: liftover_to
           system: ga4gh-gks-term:allele-relation
     matchCharacteristic:
+      type: MappableConcept
       primaryCoding:
         code: is_within
         system: ga4gh-gks-term:location-match

--- a/examples/yaml/categoricalCnv-ex3.yaml
+++ b/examples/yaml/categoricalCnv-ex3.yaml
@@ -42,10 +42,12 @@ constraints:
         - 7564455
         - 7594949
     relations:
-      - primaryCoding:
+      - type: MappableConcept
+        primaryCoding:
           code: liftover_to
           system: ga4gh-gks-term:allele-relation
     matchCharacteristic:
+      type: MappableConcept
       primaryCoding:
         code: is_within
         system: ga4gh-gks-term:location-match

--- a/examples/yaml/functionVariant-ex1.yaml
+++ b/examples/yaml/functionVariant-ex1.yaml
@@ -5,6 +5,7 @@ description: An example categorical variant that uses FeatureContextConstraint a
 constraints:
   - type: FeatureContextConstraint
     featureContext:
+      type: MappableConcept
       id: hgnc:7989
       conceptType: Gene
       name: NRAS
@@ -17,6 +18,7 @@ constraints:
           - https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:7989
   - type: FunctionConstraint
     functionConsequence:
+      type: MappableConcept
       id: SO:0002219
       name: functionally normal
       primaryCoding:

--- a/examples/yaml/functionVariant-ex2.yaml
+++ b/examples/yaml/functionVariant-ex2.yaml
@@ -5,6 +5,7 @@ description: An example categorical variant that uses FeatureContextConstraint a
 constraints:
   - type: FeatureContextConstraint
     featureContext:
+      type: MappableConcept
       id: hgnc:1101
       conceptType: Gene
       name: BRCA2
@@ -17,6 +18,7 @@ constraints:
           - https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1101
   - type: FunctionConstraint
     functionConsequence:
+      type: MappableConcept
       id: SO:0002054
       name: loss of function
       primaryCoding:

--- a/examples/yaml/functionVariant-ex3.yaml
+++ b/examples/yaml/functionVariant-ex3.yaml
@@ -46,6 +46,7 @@ constraints:
         sequence: A
   - type: FeatureContextConstraint
     featureContext:
+      type: MappableConcept
       id: hgnc:8975
       conceptType: Gene
       name: PIK3CA
@@ -57,6 +58,7 @@ constraints:
           - https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:8975
   - type: FunctionConstraint
     functionConsequence:
+      type: MappableConcept
       id: SO:0002053
       name: gain of function
       primaryCoding:

--- a/examples/yaml/proteinSequenceConsequence-ex1.yaml
+++ b/examples/yaml/proteinSequenceConsequence-ex1.yaml
@@ -103,7 +103,8 @@ constraints:
         type: LiteralSequenceExpression
         sequence: R
     relations:
-      - primaryCoding:
+      - type: MappableConcept
+        primaryCoding:
           code: translation_of
           system: http://www.sequenceontology.org
           iris:

--- a/examples/yaml/proteinSequenceConsequence-ex2.yaml
+++ b/examples/yaml/proteinSequenceConsequence-ex2.yaml
@@ -79,7 +79,8 @@ constraints:
         type: LiteralSequenceExpression
         sequence: '*'
     relations:
-      - primaryCoding:
+      - type: MappableConcept
+        primaryCoding:
           code: translation_of
           system: http://www.sequenceontology.org
           iris:

--- a/examples/yaml/tp53-copy-loss.annotated.yaml
+++ b/examples/yaml/tp53-copy-loss.annotated.yaml
@@ -70,10 +70,12 @@ constraints:
         - 7687490
         - null
     relations:
-      - primaryCoding:
+      - type: MappableConcept
+        primaryCoding:
           code: liftover_to
           system: ga4gh-gks-term:allele-relation
     matchCharacteristic:
+      type: MappableConcept
       primaryCoding:
         code: is_within
         system: ga4gh-gks-term:location-match
@@ -86,6 +88,7 @@ constraints:
       # This ‘id’ is unique within a given system, but may or may not be globally unique outside the system.
       # It is used within a system to reference an object from another.
       # id is not intended or required ot be human-readable.  In this case it just happens to be so
+      type: MappableConcept
       id: TP53
 
       # A primary name for the concept (usually a human-readable one)

--- a/examples/yaml/tp53-copy-loss.yaml
+++ b/examples/yaml/tp53-copy-loss.yaml
@@ -38,15 +38,18 @@ constraints:
         - 7687490
         - null
     relations:
-      - primaryCoding:
+      - type: MappableConcept
+        primaryCoding:
           code: liftover_to
           system: ga4gh-gks-term:allele-relation
     matchCharacteristic:
+      type: MappableConcept
       primaryCoding:
         code: is_within
         system: ga4gh-gks-term:location-match
   - type: FeatureContextConstraint
     featureContext:
+      type: MappableConcept
       id: hgnc:11998
       name: TP53
       conceptType: Gene

--- a/schema/cat-vrs/cat-vrs-source.yaml
+++ b/schema/cat-vrs/cat-vrs-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/cat-vrs-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/cat-vrs-source.yaml"
 title: GA4GH-Cat-VRS-Definitions
 type: object
 strict: true
@@ -9,8 +9,8 @@ imports:
   vrs: ../vrs/vrs-source.yaml
 
 namespaces:
-  gks.core: /ga4gh/schema/gks-core/1.1.0/json/
-  vrs: /ga4gh/schema/vrs/2.0.1/json/
+  gks.core: /ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/
+  vrs: /ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/
 
 $defs:
 

--- a/schema/cat-vrs/json/AdjacencyConstraint
+++ b/schema/cat-vrs/json/AdjacencyConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/AdjacencyConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/AdjacencyConstraint",
    "title": "AdjacencyConstraint",
    "type": "object",
    "maturity": "draft",
@@ -21,19 +21,19 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/UnspecifiedElement"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/UnspecifiedElement"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+                  "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                },
                {
-                  "$ref": "/ga4gh/schema/vrs/2.0.1/json/Location"
+                  "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Location"
                },
                {
-                  "$ref": "/ga4gh/schema/vrs/2.0.1/json/Terminus"
+                  "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Terminus"
                }
             ]
          }
@@ -43,12 +43,12 @@
          "description": "Functional domains whose presence or absence is required to satisfy the adjacency.",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/FunctionalDomain"
+            "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/FunctionalDomain"
          }
       },
       "linker": {
          "description": "The sequence found between the adjoined elements.",
-         "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceExpression"
+         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceExpression"
       },
       "orderKnown": {
          "type": "boolean",

--- a/schema/cat-vrs/json/CanonicalAllele
+++ b/schema/cat-vrs/json/CanonicalAllele
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/CanonicalAllele",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CanonicalAllele",
    "title": "CanonicalAllele",
    "type": "object",
    "maturity": "trial use",
    "description": "A canonical allele is defined by an Allele that is representative of a collection of congruent Alleles, each of which depict the same nucleic acid on different underlying reference sequences. Congruent representations of an Allele often exist across different genome assemblies and associated cDNA transcript representations.",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
       },
       {
          "properties": {
@@ -17,7 +17,7 @@
                "contains": {
                   "allOf": [
                      {
-                        "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/DefiningAlleleConstraint"
+                        "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/DefiningAlleleConstraint"
                      },
                      {
                         "type": "object",

--- a/schema/cat-vrs/json/CategoricalCnv
+++ b/schema/cat-vrs/json/CategoricalCnv
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalCnv",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalCnv",
    "title": "CategoricalCnv",
    "type": "object",
    "maturity": "draft",
    "description": "A representation of the constraints for matching knowledge about CNVs.",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
       },
       {
          "properties": {
@@ -20,7 +20,7 @@
                      "contains": {
                         "allOf": [
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/DefiningLocationConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/DefiningLocationConstraint"
                            },
                            {
                               "properties": {
@@ -47,10 +47,10 @@
                      "contains": {
                         "oneOf": [
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CopyCountConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CopyCountConstraint"
                            },
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CopyChangeConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CopyChangeConstraint"
                            }
                         ]
                      }

--- a/schema/cat-vrs/json/CategoricalVariant
+++ b/schema/cat-vrs/json/CategoricalVariant
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant",
    "title": "CategoricalVariant",
    "type": "object",
    "maturity": "trial use",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -50,10 +50,10 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                },
                {
-                  "$ref": "/ga4gh/schema/vrs/2.0.1/json/Variation"
+                  "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Variation"
                }
             ]
          }
@@ -64,25 +64,25 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/AdjacencyConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/AdjacencyConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CopyChangeConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CopyChangeConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CopyCountConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CopyCountConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/DefiningAlleleConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/DefiningAlleleConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/DefiningLocationConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/DefiningLocationConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/FeatureContextConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/FeatureContextConstraint"
                },
                {
-                  "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/FunctionConstraint"
+                  "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/FunctionConstraint"
                }
             ]
          }
@@ -91,7 +91,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/ConceptMapping"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/ConceptMapping"
          },
          "description": "A list of mappings to concepts in terminologies or code systems. Each mapping should include a coding and a relation."
       }

--- a/schema/cat-vrs/json/Constraint
+++ b/schema/cat-vrs/json/Constraint
@@ -1,31 +1,31 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/Constraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/Constraint",
    "title": "Constraint",
    "type": "object",
    "maturity": "trial use",
    "description": "Constraints are used to construct an intensional semantics of categorical variant types.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/AdjacencyConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/AdjacencyConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CopyChangeConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CopyChangeConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CopyCountConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CopyCountConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/DefiningAlleleConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/DefiningAlleleConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/DefiningLocationConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/DefiningLocationConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/FeatureContextConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/FeatureContextConstraint"
       },
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/FunctionConstraint"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/FunctionConstraint"
       }
    ]
 }

--- a/schema/cat-vrs/json/CopyChangeConstraint
+++ b/schema/cat-vrs/json/CopyChangeConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/CopyChangeConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CopyChangeConstraint",
    "title": "CopyChangeConstraint",
    "type": "object",
    "maturity": "draft",

--- a/schema/cat-vrs/json/CopyCountConstraint
+++ b/schema/cat-vrs/json/CopyCountConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/CopyCountConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CopyCountConstraint",
    "title": "CopyCountConstraint",
    "type": "object",
    "maturity": "trial use",
@@ -16,7 +16,7 @@
          "description": "The precise value or range of copies members of this categorical variant must satisfy.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Range"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Range"
             },
             {
                "type": "integer"

--- a/schema/cat-vrs/json/DefiningAlleleConstraint
+++ b/schema/cat-vrs/json/DefiningAlleleConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/DefiningAlleleConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/DefiningAlleleConstraint",
    "title": "DefiningAlleleConstraint",
    "type": "object",
    "maturity": "trial use",
@@ -15,10 +15,10 @@
       "allele": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Allele"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Allele"
             }
          ]
       },
@@ -26,7 +26,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
          },
          "description": "Defined relationships from which members relate to the defining allele."
       }

--- a/schema/cat-vrs/json/DefiningLocationConstraint
+++ b/schema/cat-vrs/json/DefiningLocationConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/DefiningLocationConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/DefiningLocationConstraint",
    "title": "DefiningLocationConstraint",
    "type": "object",
    "maturity": "trial use",
@@ -15,10 +15,10 @@
       "location": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceLocation"
             }
          ]
       },
@@ -26,13 +26,13 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
          },
          "description": "Defined relationships from which members relate to the defining location."
       },
       "matchCharacteristic": {
          "description": "A characteristic of the location that is used to match the defining location to member locations.",
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
       }
    },
    "required": [

--- a/schema/cat-vrs/json/FeatureContextConstraint
+++ b/schema/cat-vrs/json/FeatureContextConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/FeatureContextConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/FeatureContextConstraint",
    "title": "FeatureContextConstraint",
    "type": "object",
    "maturity": "draft",
@@ -14,7 +14,7 @@
       },
       "featureContext": {
          "description": "A feature identifier.",
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
       }
    },
    "required": [

--- a/schema/cat-vrs/json/FunctionConstraint
+++ b/schema/cat-vrs/json/FunctionConstraint
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/FunctionConstraint",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/FunctionConstraint",
    "title": "FunctionConstraint",
    "type": "object",
    "maturity": "draft",
@@ -14,7 +14,7 @@
       },
       "functionConsequence": {
          "description": "The functional consequence of members of this categorical variant, as defined by an external ontology. We recommend using one of the defined terms from [The Sequence Ontology](http://www.sequenceontology.org). See Implementation Guidance for more details. ",
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
       },
       "description": {
          "description": "A free-text description of the function change.",

--- a/schema/cat-vrs/json/FunctionVariant
+++ b/schema/cat-vrs/json/FunctionVariant
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/FunctionVariant",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/FunctionVariant",
    "title": "FunctionVariant",
    "type": "object",
    "maturity": "draft",
    "description": "A representation of the constraints for matching knowledge about function variants; e.g., gain-of-function or loss-of-function.",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
       },
       {
          "properties": {
@@ -19,7 +19,7 @@
                      "contains": {
                         "allOf": [
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/FunctionConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/FunctionConstraint"
                            }
                         ]
                      }
@@ -28,13 +28,13 @@
                      "contains": {
                         "anyOf": [
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/DefiningAlleleConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/DefiningAlleleConstraint"
                            },
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/DefiningLocationConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/DefiningLocationConstraint"
                            },
                            {
-                              "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/FeatureContextConstraint"
+                              "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/FeatureContextConstraint"
                            }
                         ]
                      }

--- a/schema/cat-vrs/json/FunctionalDomain
+++ b/schema/cat-vrs/json/FunctionalDomain
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/FunctionalDomain",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/FunctionalDomain",
    "title": "FunctionalDomain",
    "type": "object",
    "maturity": "draft",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -45,7 +45,7 @@
       },
       "location": {
          "description": "A Sequence Location for the domain.",
-         "$ref": "/ga4gh/schema/vrs/2.0.1/json/Location"
+         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Location"
       },
       "status": {
          "type": "string",

--- a/schema/cat-vrs/json/GeneFusion
+++ b/schema/cat-vrs/json/GeneFusion
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/GeneFusion",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/GeneFusion",
    "title": "GeneFusion",
    "type": "object",
    "maturity": "draft",
    "description": "A representation of the joining of two genes resulting in a chimeric transcript and/or novel interaction between a rearranged regulatory elements with the expression of a partner gene product (a regulatory fusion).",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
       },
       {
          "properties": {
@@ -17,7 +17,7 @@
                "contains": {
                   "allOf": [
                      {
-                        "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/AdjacencyConstraint"
+                        "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/AdjacencyConstraint"
                      },
                      {
                         "properties": {
@@ -25,16 +25,16 @@
                               "contains": {
                                  "anyOf": [
                                     {
-                                       "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                                       "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                                     },
                                     {
-                                       "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+                                       "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
                                     },
                                     {
-                                       "$ref": "/ga4gh/schema/vrs/2.0.1/json/Location"
+                                       "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Location"
                                     },
                                     {
-                                       "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/UnspecifiedElement"
+                                       "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/UnspecifiedElement"
                                     }
                                  ]
                               }

--- a/schema/cat-vrs/json/ProteinSequenceConsequence
+++ b/schema/cat-vrs/json/ProteinSequenceConsequence
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/ProteinSequenceConsequence",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/ProteinSequenceConsequence",
    "title": "ProteinSequenceConsequence",
    "type": "object",
    "maturity": "trial use",
    "description": "A change that occurs in a protein sequence as a result of genomic changes. Due to the degenerate nature of the genetic code, there are often several genomic changes that can cause a protein sequence consequence. The protein sequence consequence, like a CanonicalAllele, is defined by an Allele that is representative of a collection of congruent Protein Alleles that share the same altered codon(s).",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+         "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
       },
       {
          "properties": {
@@ -15,7 +15,7 @@
                "contains": {
                   "allOf": [
                      {
-                        "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/DefiningAlleleConstraint"
+                        "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/DefiningAlleleConstraint"
                      },
                      {
                         "type": "object",

--- a/schema/cat-vrs/json/UnspecifiedElement
+++ b/schema/cat-vrs/json/UnspecifiedElement
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/json/UnspecifiedElement",
+   "$id": "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/UnspecifiedElement",
    "title": "UnspecifiedElement",
    "type": "object",
    "maturity": "draft",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/cat-vrs/recipes-source.yaml
+++ b/schema/cat-vrs/recipes-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/cat-vrs/1.0.0/recipes-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/recipes-source.yaml"
 title: GA4GH-Cat-VRS-Recipe-Definitions
 type: object
 
@@ -9,8 +9,8 @@ imports:
   vrs: ../vrs/vrs-source.yaml
 
 namespaces:
-  gks.core: /ga4gh/schema/gks-core/1.1.0/json/
-  vrs: /ga4gh/schema/vrs/2.0.1/json/
+  gks.core: /ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/
+  vrs: /ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/
 
 $defs:
   ProteinSequenceConsequence:


### PR DESCRIPTION
…ncept schema

- Point vrs submodule at branch 2.1.0-ballot.2026-07
- Bump cat-vrs $id to 1.1.0-ballot.2026-07.1; gks-core to 1.2.0-ballot.2026-07.1; vrs to 2.1.0-ballot.2026-07.1 in source + built JSON
- Add required `type: MappableConcept` to all MappableConcept instances in examples/yaml (gks-core now requires it)

## Link to the corresponding Issue

## Summary of the Pull Request

## Pull Request checklist

### Required

- [ ] The title of this Pull Request accurately reflects the scope and content of the linked Issue.
- [ ] The branch passes all pre-commit hooks (Run `pre-commit run --all-files` from the root directory).
- [ ] The branch passes all tests (Run `pytest tests/` from the root directory).

### Required if the schema or examples were contributed to

- [ ] The schema `def/` and `json/` files have been recompiled and committed (Run `cd schema; make all` from the root directory).
- [ ] Examples `json/` files have been compiled and committed (Run `cd examples; make all` from the root directory).
- [ ] Tests have been created or updated.
- [ ] Schema changes have been documented (existing files updated or new files created in `docs/source/`).
- [ ] Any new schema definition `.rst` files have been registered in the documentation structure.
- [ ] Documentation has been regenerated and committed (Run `cd docs; make clean watch &` from the root directory to compile documentation).
